### PR TITLE
Fix locale key in config sample

### DIFF
--- a/samples/crtools.ini
+++ b/samples/crtools.ini
@@ -116,11 +116,11 @@ no_promote=#9ULGLRCL
 # will always recommend kicking if they are in the clan
 blacklist=#9ULGLRCL
 
+[crtools]
 # Locale for translation. Valid values are
 # - en
 # - fr
 locale=en
 
-[crtools]
 # Turns on debug mode if True
 debug=True


### PR DESCRIPTION
The locale key was not in the right section in the sample config file. It solves #28