### PR TITLE
Generalize locale switch instructions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Usage:
 
 optional arguments:
   -h, --help           show this help message and exit
-  --locale LOCALE      Locale if language other than English is desired. Currently, only "fr" is valid.
+  --locale LOCALE      Locale if language other than English is desired (see `Other languages/locales`_).
   --config FILE        configuration file for this app.
   --api_key KEY        API key for developer.clashroyale.com
   --clan CLAN          Clan ID from Clash Royale. If it starts with a '#', clan ID must be quoted.


### PR DESCRIPTION
As more locales are added, it'll become unruly to list them all in the arguments grid. Instead, the user should be redirected to the locale section for a list of choices.